### PR TITLE
Change literal '&' sign to '&samp;'

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.audio.eco99music" name="eco99music" version="0.0.4" provider-name="Nir Elbaz & Noam Stolero">
+<addon id="plugin.audio.eco99music" name="eco99music" version="0.0.4" provider-name="Nir Elbaz &amp; Noam Stolero">
     <requires>
         <import addon="xbmc.python" version="2.25.0"/>
         <import addon="script.module.requests" version="2.12.4"/>


### PR DESCRIPTION
@nire0510 Sorry for the mess, i added an illegal & sign and broke the plugin installation.
I tested this properly, downloaded the zip from my branch and installed without errors.
